### PR TITLE
Add missing `scripts` in component.json

### DIFF
--- a/component.json
+++ b/component.json
@@ -8,5 +8,8 @@
   "development": {
     "component/assert": "*",
     "matthewmueller/generator-support": "*"
-  }
+  },
+  "scripts": [
+    "index.js"
+  ]
 }


### PR DESCRIPTION
This would make `wrap-fn` usable with Component.
Not sure if Duo guesses a main script, if not, this would also fix Duo.

Side note: maybe a `main` property would also work/be cleaner?
